### PR TITLE
fixes issue with updating fields with reserved names

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,16 +10,25 @@
     "email": "ilmari.vacklin@iki.fi",
     "url": "https://github.com/wolverian"
   },
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "node test.js",
     "coverage": "nyc yarn test",
-    "report": "nyc report --reporter=text-lcov"
+    "report": "nyc report --reporter=text-lcov",
+    "precommit": "lint-staged"
   },
   "devDependencies": {
     "codacy-coverage": "^2.0.2",
     "eslint-config-motley": "^8.0.1",
     "nyc": "^11.1.0",
     "tape": "^4.6.2"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --single-quote --trailing-comma all --write",
+      "git add"
+    ]
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,21 +2,32 @@ const test = require("tape")
 const merge = require("./index")
 
 test("SET", (t) => {
-  t.plan(2)
+  t.plan(3)
 
   t.deepEqual(
     merge({ x: 42 }),
     {
-      UpdateExpression: "SET x = :x",
-      ExpressionAttributeValues: { ':x': 42 }
+      UpdateExpression: "SET #x = :x",
+      ExpressionAttributeValues: { ':x': 42 },
+      ExpressionAttributeNames: { '#x': 'x' }
+    }
+  )
+
+  t.deepEqual(
+    merge({ name: 'some name' }),
+    {
+      UpdateExpression: "SET #name = :name",
+      ExpressionAttributeValues: { ':name': 'some name' },
+      ExpressionAttributeNames: { '#name': 'name' }
     }
   )
 
   t.deepEqual(
     merge({ x: { y: "foo", z: { w: 42 } }, q: 0 }),
     {
-      UpdateExpression: "SET x.y = :x_y, x.z.w = :x_z_w, q = :q",
-      ExpressionAttributeValues: { ":x_y": "foo", ":x_z_w": 42, ":q": 0 }
+      UpdateExpression: "SET #x.y = :x_y, #x.z.w = :x_z_w, #q = :q",
+      ExpressionAttributeValues: { ":x_y": "foo", ":x_z_w": 42, ":q": 0 },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
     }
   )
 })
@@ -27,8 +38,9 @@ test("Combination", (t) => {
   t.deepEqual(
     merge({ x: { y: [1, 2], z: "x" }, q: 10 }),
     {
-      UpdateExpression: "SET x.z = :x_z, q = :q ADD x.y :x_y0, x.y :x_y1",
-      ExpressionAttributeValues: { ":x_z": "x", ":q": 10, ":x_y0": 1, ":x_y1": 2 }
+      UpdateExpression: "SET #x.z = :x_z, #q = :q ADD #x.y :x_y0, #x.y :x_y1",
+      ExpressionAttributeValues: { ":x_z": "x", ":q": 10, ":x_y0": 1, ":x_y1": 2 },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
     }
   )
 })
@@ -40,28 +52,31 @@ test("Functions", (t) => {
   t.deepEqual(
     merge({ x: { y: () => "foo", z: "x" }, q: 10 }),
     {
-      UpdateExpression: "SET x.y = :x_y, x.z = :x_z, q = :q",
-      ExpressionAttributeValues: { ":x_y": "foo", ":q": 10, ":x_z": "x" }
+      UpdateExpression: "SET #x.y = :x_y, #x.z = :x_z, #q = :q",
+      ExpressionAttributeValues: { ":x_y": "foo", ":q": 10, ":x_z": "x" },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
     }
   )
 })
 
 test("Null values should be deleted", (t) => {
-  t.plan(3)
+  t.plan(4)
 
   t.deepEqual(
     merge({ x: null }),
     {
-      UpdateExpression: "DELETE x",
-      ExpressionAttributeValues: {}
+      UpdateExpression: "DELETE #x",
+      ExpressionAttributeValues: {},
+      ExpressionAttributeNames: { '#x': 'x' }
     }
   )
 
   t.deepEqual(
     merge({ x: null, y: "foo" }),
     {
-      UpdateExpression: "SET y = :y DELETE x",
-      ExpressionAttributeValues: { ":y": "foo" }
+      UpdateExpression: "SET #y = :y DELETE #x",
+      ExpressionAttributeValues: { ":y": "foo" },
+      ExpressionAttributeNames: { '#x': 'x', '#y': 'y' }
     }
   )
 
@@ -69,8 +84,18 @@ test("Null values should be deleted", (t) => {
   t.deepEqual(
     merge({ x: { y: null, z: { w: 42 } }, q: 0 }),
     {
-      UpdateExpression: "SET x.z.w = :x_z_w, q = :q DELETE x.y",
-      ExpressionAttributeValues: { ":x_z_w": 42, ":q": 0 }
+      UpdateExpression: "SET #x.z.w = :x_z_w, #q = :q DELETE #x.y",
+      ExpressionAttributeValues: { ":x_z_w": 42, ":q": 0 },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
+    }
+  )
+
+  t.deepEqual(
+    merge({ x: { y: null }, q: 0 }),
+    {
+      UpdateExpression: "SET #q = :q DELETE #x.y",
+      ExpressionAttributeValues: { ":q": 0 },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
     }
   )
 })
@@ -80,14 +105,15 @@ test("Undefineds should be left alone", (t) => {
 
   t.deepEqual(
     merge({ x: undefined }),
-    { UpdateExpression: "", ExpressionAttributeValues: {} }
+    { UpdateExpression: "", ExpressionAttributeValues: {}, ExpressionAttributeNames: {} }
   )
 
   t.deepEqual(
     merge({ x: { y: undefined, z: { w: 42 } }, q: 0 }),
     {
-      UpdateExpression: "SET x.z.w = :x_z_w, q = :q",
-      ExpressionAttributeValues: { ":x_z_w": 42, ":q": 0 }
+      UpdateExpression: "SET #x.z.w = :x_z_w, #q = :q",
+      ExpressionAttributeValues: { ":x_z_w": 42, ":q": 0 },
+      ExpressionAttributeNames: { '#x': 'x', '#q': 'q' }
     }
   )
 })
@@ -98,8 +124,9 @@ test("Booleans", (t) => {
   t.deepEqual(
     merge({ x: false }),
     {
-      UpdateExpression: "SET x = :x",
-      ExpressionAttributeValues: { ":x": false }
+      UpdateExpression: "SET #x = :x",
+      ExpressionAttributeValues: { ":x": false },
+      ExpressionAttributeNames: { '#x': 'x' }
     }
   )
 })


### PR DESCRIPTION
This fixes #19 by always aliasing the field names and setting `ExpressionAttributeNames` on the returned object.